### PR TITLE
provider: Changing from this.props to nextProps

### DIFF
--- a/src/components/provider.js
+++ b/src/components/provider.js
@@ -141,7 +141,7 @@ class IntlProvider extends Component {
   }
 
   static getDerivedStateFromProps(nextProps, prevState) {
-    const {intl: intlContext} = this.props;
+    const { intl: intlContext } = nextProps;
 
     // Build a whitelisted config object from `props`, defaults, and
     // `props.intl`, if an <IntlProvider> exists in the ancestry.


### PR DESCRIPTION
Using `this.props` inside `getDerivedStateFromProps` caused a TypeError since you can't use `this` inside static methods. Changing to `nextProps` solves this issue. I'm not sure of the intention of this code, so I'm not sure if it's right to use `nextProps` in this case. Please have a look!